### PR TITLE
Remove ideas nav category

### DIFF
--- a/code/static-site-generator/src/theme/styles.rs
+++ b/code/static-site-generator/src/theme/styles.rs
@@ -195,10 +195,6 @@ pub fn get_default_styles() -> String {
         text-decoration: none;
     }
 
-    .tagline {
-        margin: 0.5rem 0 1rem;
-        opacity: 0.8;
-    }
 
     .site-nav {
         display: flex;
@@ -258,9 +254,6 @@ pub fn get_default_styles() -> String {
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
     }
 
-    body.scrolled .tagline {
-        display: none;
-    }
 
     /* Hide search in minimal theme */
     .nav-search {

--- a/code/static-site-generator/src/theme/templates.rs
+++ b/code/static-site-generator/src/theme/templates.rs
@@ -24,7 +24,6 @@ const BASE_TEMPLATE: &str = r##"<!DOCTYPE html>
             <nav class="site-nav">
                 <a href="{base_url}projects/" class="nav-item {projects_active}">Projects</a>
                 <a href="{base_url}areas/" class="nav-item {areas_active}">Areas</a>
-                <a href="{base_url}ideas/" class="nav-item">Ideas</a>
                 <a href="{base_url}resources/" class="nav-item {resources_active}">Resources</a>
                 <a href="{base_url}archives/" class="nav-item {archives_active}">Archives</a>
             </nav>
@@ -32,7 +31,6 @@ const BASE_TEMPLATE: &str = r##"<!DOCTYPE html>
                 <span class="burger"></span>
             </button>
         </div>
-        <p class="tagline">A PARA-style knowledge forge</p>
     </header>
     
     <main id="main-content">

--- a/context/projects/navigation-cleanup-remove-ideas-category.md
+++ b/context/projects/navigation-cleanup-remove-ideas-category.md
@@ -1,0 +1,25 @@
+---
+title: Remove Ideas Category from Navigation
+category: projects
+status: completed
+created: 2025-06-13T00:00:00Z
+modified: 2025-06-13T00:00:00Z
+tags:
+  - static-site-generator
+  - cleanup
+  - para
+---
+
+# Remove Ideas Category from Navigation
+
+## Summary
+
+The navigation previously included an **Ideas** link that did not align with the PARA structure. The base template also displayed the tagline "A PARA-style knowledge forge." Both items were removed to keep the site focused on the four official PARA categories.
+
+## Process Steps
+
+1. Deleted the Ideas link from the header navigation in `templates.rs`.
+2. Removed the tagline markup and its CSS rules from `styles.rs`.
+3. Verified the remaining navigation highlights active categories correctly.
+
+These changes simplify the UI and avoid confusion about unsupported categories.


### PR DESCRIPTION
## Summary
- clean up base template navigation
- remove tagline from templates and CSS
- document why we dropped the ideas category

## Testing
- `cd code/static-site-generator && make check`

------
https://chatgpt.com/codex/tasks/task_e_684c34613fa48333bb899681300aea24