### PR TITLE
Implement notes-on-issues P-00 skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Notes-on-Issues
+
+Monorepo for the Notes-on-Issues application.

--- a/context/projects/notes-on-issues/p00-monorepo-skeleton.md
+++ b/context/projects/notes-on-issues/p00-monorepo-skeleton.md
@@ -1,0 +1,18 @@
+---
+title: 'Notes-on-Issues P-00 Monorepo Skeleton'
+category: projects
+created: 2025-06-14T00:00:00Z
+modified: 2025-06-14T00:00:00Z
+tags:
+  - codex
+  - notes-on-issues
+  - implementation
+---
+
+Implemented Prompt P-00 to bootstrap the pnpm-based monorepo:
+
+- Added `pnpm-workspace.yaml` listing `packages/*`.
+- Created root `package.json` with minimal scripts and pnpm configuration.
+- Initialized empty `packages/` directory with `.gitkeep`.
+- Added placeholder `README.md`.
+- Added `tools/self-check.sh` to verify pnpm is installed.

--- a/context/projects/notes-on-issues/prompt-plan.md
+++ b/context/projects/notes-on-issues/prompt-plan.md
@@ -40,6 +40,9 @@ Return a unix-style patch (diff) that applies cleanly to root.
 ```
 
 ```
+**Status**: ✅ Complete
+**Completion**: 2025-06-14
+**Notes**: Monorepo skeleton created with pnpm workspace, package.json, README, and self-check script.
 Prompt P-01 — Toolchain & Quality Gates
 
 Context: Repo contains the skeleton from P-00.

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
     "lint": "eslint . --ext .ts,.tsx --no-error-on-unmatched-pattern",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --build --verbose"
+    "typecheck": "tsc --build --verbose",
+    "test": "bash tools/self-check.sh",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1"
-  }
+  },
+  "private": true,
+  "packageManager": "pnpm@10.5.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/tools/self-check.sh
+++ b/tools/self-check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# ABOUTME: Checks that pnpm is available in the environment.
+# ABOUTME: Prints pnpm version and exits successfully.
+
+set -euo pipefail
+pnpm -v


### PR DESCRIPTION
## Summary
- initialize notes-on-issues monorepo
- add pnpm workspace file
- create placeholder README and packages dir
- add self-check script and npm scripts
- document implementation and update prompt status

## Testing
- `npm run lint -- --fix`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de608587883338c61dc59b169cc92