### PR TITLE
Implement P-01 toolchain setup under notes-on-issues package

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 npx lint-staged --config lint-staged.config.js
+pnpm --silent lint
+pnpm --silent test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,11 @@ This repository uses AGENTS.md to coordinate contributions from automated agents
 
 - **Review `CLAUDE.md` before starting work.** It contains additional rules and best practices that augment these instructions.
 - **Document every change.** Pull requests will only be accepted if they include thorough documentation in the `context/` directory. Follow the PARA system (Projects, Areas, Resources, Archives) and place documents in the appropriate location.
+
   - Any document created must be tagged with `codex`
+
+- The `notes-on-issues` project lives under `code/notes-on-issues`. Keep all of
+  its source, tests, and configs inside this directory.
 
 # Writing code
 

--- a/code/notes-on-issues/package.json
+++ b/code/notes-on-issues/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "notes-on-issues",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist"
+  }
+}

--- a/code/notes-on-issues/tests/health.spec.ts
+++ b/code/notes-on-issues/tests/health.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('health check', () => {
+  it('true is true', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/code/notes-on-issues/tsconfig.json
+++ b/code/notes-on-issues/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/code/notes-on-issues/tsconfig.test.json
+++ b/code/notes-on-issues/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/code/notes-on-issues/vitest.config.ts
+++ b/code/notes-on-issues/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    globals: true,
+    include: ['tests/**/*.spec.ts'],
+  },
+});

--- a/context/projects/notes-on-issues/p01-toolchain-quality-gates.md
+++ b/context/projects/notes-on-issues/p01-toolchain-quality-gates.md
@@ -1,0 +1,21 @@
+---
+title: 'Notes-on-Issues P-01 Toolchain and Quality Gates'
+category: projects
+created: 2025-06-14T00:00:00Z
+modified: 2025-06-14T00:00:00Z
+tags:
+  - codex
+  - notes-on-issues
+  - implementation
+---
+
+Implemented Prompt P-01 adding tooling and baseline quality gates:
+
+- Installed TypeScript, ESLint, Prettier, Husky, lint-staged, and Vitest.
+- Added `tsconfig.base.json` with strict options.
+- Placed all project tooling under `code/notes-on-issues`.
+- Configured ESLint and Prettier via `eslint.config.mjs` and `.prettierrc.json`.
+- Set up Husky pre-commit hook running lint, tests, and lint-staged formatting.
+- Created `lint-staged.config.js` to format and lint staged files.
+- Added minimal `code/notes-on-issues/vitest.config.ts` and health check test.
+- Updated `tools/self-check.sh` to run the Vitest suite with this config.

--- a/context/projects/notes-on-issues/prompt-plan.md
+++ b/context/projects/notes-on-issues/prompt-plan.md
@@ -64,11 +64,15 @@ Context: Repo contains the skeleton from P-00.
    - `lint`, `test` (jest placeholder), `prepare` (`husky install`).
 
 **Tests**
-- Write a minimal Vitest config (`vitest.config.ts`) and one passing test `tools/health.spec.ts` asserting `true === true`.
-- Add CI step in `tools/self-check.sh` to run `pnpm vitest run --silent`.
+- Write a minimal Vitest config (`code/notes-on-issues/vitest.config.ts`) and one passing test `code/notes-on-issues/tests/health.spec.ts` asserting `true === true`.
+- Add CI step in `tools/self-check.sh` to run `pnpm vitest run --config code/notes-on-issues/vitest.config.ts --silent`.
 
 Return patch only.
 ```
+
+**Status**: ✅ Complete
+**Completion**: 2025-06-14
+**Notes**: Tooling configured with TypeScript, ESLint, Prettier, Husky, lint-staged, and Vitest under `code/notes-on-issues`.
 
 ```
 Prompt P-02 — Bootstrap GitHub Action CI

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default [
       '**/*.js',
       '**/*.mjs',
       'code/mcp-server/**',
+      'code/forge-mcp/**',
     ],
   },
   js.configs.recommended,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  '*.{ts,tsx,js,json,md}': ['prettier --write', 'eslint --fix'],
   'code/**/*.{ts,tsx}': ['eslint --fix', 'prettier --write'],
   'code/**/*.{json,md,yml,yaml}': ['prettier --write'],
   '*.{json,md,yml,yaml}': ['prettier --write'],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint-staged": "^16.1.0",
     "prettier": "^3.5.3",
     "ts-jest": "^29.3.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.3"
   },
   "scripts": {
     "prepare": "husky",

--- a/tools/self-check.sh
+++ b/tools/self-check.sh
@@ -4,3 +4,4 @@
 
 set -euo pipefail
 pnpm -v
+pnpm vitest run --config code/notes-on-issues/vitest.config.ts --silent

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "files": [],
+  "include": ["tools/**/*.ts", "code/notes-on-issues/vitest.config.ts"],
   "references": [
-    { "path": "./code/mcp-server" }
+    { "path": "./code/forge-mcp" },
+    { "path": "./code/notes-on-issues" }
   ]
 }


### PR DESCRIPTION
## Summary
- move vitest config and tests into `code/notes-on-issues`
- adjust `self-check.sh` and `tsconfig.json` for new location
- document tooling location in AGENTS guidelines
- note path updates in project docs
- add minimal package and tsconfig for notes-on-issues

## Testing
- `pnpm --silent lint`
- `pnpm --silent test`


------
https://chatgpt.com/codex/tasks/task_e_684de897b2f48333a42830d677f52513